### PR TITLE
New Game: PAC-MAN Championship Edition DX+

### DIFF
--- a/HintMachine/Games/PacManChampionshipEditionDXConnector.cs
+++ b/HintMachine/Games/PacManChampionshipEditionDXConnector.cs
@@ -1,0 +1,40 @@
+namespace HintMachine.Games
+{
+    public class PacManChampionshipEditionDXConnector : IGameConnector
+    {
+        private readonly HintQuestCumulative _scoreQuest = new HintQuestCumulative
+        {
+            Name = "Cumulative Score",
+            GoalValue = 400000,
+        };
+
+        private ProcessRamWatcher _ram = null;
+
+        public PacManChampionshipEditionDXConnector()
+        {
+            Name = "PAC-MAN Championship Edition DX+";
+            Description = "It's time to gear up! Get ready for more ghost chain gobbling and frantic action in PAC-MAN CE-DX+!";
+            SupportedVersions = "Steam";
+            Author = "Serpent.AI";
+
+            Quests.Add(_scoreQuest);
+        }
+
+        public override bool Connect()
+        {
+            _ram = new ProcessRamWatcher("PAC-MAN");
+            return _ram.TryConnect();
+        }
+
+        public override void Disconnect()
+        {
+            _ram = null;
+        }
+
+        public override bool Poll()
+        {
+            _scoreQuest.UpdateValue(_ram.ReadUint32(_ram.BaseAddress + 0x33CA14));
+            return true;
+        }
+    }
+}

--- a/HintMachine/Globals.cs
+++ b/HintMachine/Globals.cs
@@ -34,6 +34,7 @@ namespace HintMachine
             new FZeroGXConnector(),
             new IslandersConnector(),
             new DorfromantikConnector(),
+            new PacManChampionshipEditionDXConnector(),
         };
 
         public static IGameConnector FindGameFromName(string name)

--- a/HintMachine/HintMachine.csproj
+++ b/HintMachine/HintMachine.csproj
@@ -130,6 +130,7 @@
     </ApplicationDefinition>
     <Compile Include="ArchipelagoHintSession.cs" />
     <Compile Include="Games\BustAMove4Connector.cs" />
+    <Compile Include="Games\PacManChampionshipEditionDXConnector.cs" />
     <Compile Include="Games\FZeroGXConnector.cs" />
     <Compile Include="Games\DorfromantikConnector.cs" />
     <Compile Include="Games\Rollcage2Connector.cs" />

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Given its high dependency to system calls to do RAM peeking and stuff, only Wind
 - Geometry Wars : Retro Evolved
 - ISLANDERS
 - One Finger Death Punch
+- PAC-MAN Championship Edition DX+
 - Puyo Puyo Tetris
 - Rollcage Stage 2 (PS1)
 - Sonic 3 Blue Spheres


### PR DESCRIPTION
**In this PR**
* Add support for PAC-MAN Championship Edition DX+ ([Steam](https://store.steampowered.com/app/236450/PACMAN_Championship_Edition_DX))
* Quests:
  * Cumulative Score: Every 400,000 points

![image](https://github.com/CalDrac/hintMachine/assets/35039/c4ba68d6-fb19-4987-ae25-42a897d4a834)

