### PR TITLE
Reworks: Dorfromantik + ISLANDERS + PAC-MAN CE-DX + Luck be a Landlord

### DIFF
--- a/HintMachine/Games/DorfromantikConnector.cs
+++ b/HintMachine/Games/DorfromantikConnector.cs
@@ -7,7 +7,6 @@ namespace HintMachine.Games
             Name = "Score",
             GoalValue = 1000,
             MaxIncrease = 500,
-            CooldownBetweenIncrements = 3,
         };
 
         private readonly HintQuestCumulative _questQuest = new HintQuestCumulative

--- a/HintMachine/Games/DorfromantikConnector.cs
+++ b/HintMachine/Games/DorfromantikConnector.cs
@@ -4,8 +4,26 @@ namespace HintMachine.Games
     {
         private readonly HintQuestCumulative _scoreQuest = new HintQuestCumulative
         {
-            Name = "Cumulative Score",
+            Name = "Score",
             GoalValue = 1000,
+            MaxIncrease = 500,
+            TimeoutBetweenIncrements = 3,
+        };
+
+        private readonly HintQuestCumulative _questQuest = new HintQuestCumulative
+        {
+            Name = "Quests Fulfilled",
+            GoalValue = 10,
+            MaxIncrease = 5,
+            TimeoutBetweenIncrements = 20,
+        };
+
+        private readonly HintQuestCumulative _perfectQuest = new HintQuestCumulative
+        {
+            Name = "Perfect Tile Placements",
+            GoalValue = 10,
+            MaxIncrease = 3,
+            TimeoutBetweenIncrements = 20,
         };
 
         private ProcessRamWatcher _ram = null;
@@ -20,11 +38,13 @@ namespace HintMachine.Games
             Author = "Serpent.AI";
 
             Quests.Add(_scoreQuest);
+            Quests.Add(_questQuest);
+            Quests.Add(_perfectQuest);
         }
 
         public override bool Connect()
         {
-            _ram = new ProcessRamWatcher("Dorfromantik", "UnityPlayer.dll");
+            _ram = new ProcessRamWatcher("Dorfromantik", "mono-2.0-bdwgc.dll");
             return _ram.TryConnect();
         }
 
@@ -35,8 +55,70 @@ namespace HintMachine.Games
 
         public override bool Poll()
         {
-            long scoreAddress = _ram.ResolvePointerPath64(_ram.BaseAddress + 0x1AD1118, new int[] { 0x8, 0x8, 0xD0, 0x138, 0x40, 0x60, 0x180 });
-            _scoreQuest.UpdateValue(_ram.ReadUint32(scoreAddress + 0x5C));
+            // long? tilesValuePrevious = null;
+            long? scoreValuePrevious = null;
+            long? questValuePrevious = null;
+            long? perfectValuePrevious = null;
+
+            // long? tilesValue = null;
+            long? scoreValue =null;
+            long? questValue = null;
+            long? perfectValue = null;
+
+            // Backup pointer
+            // _ram.ResolvePointerPath64(_ram.BaseAddress + 0x98B9B8, new int[] { 0x28, 0x30, 0x88, 0x20, 0x90, 0x10, 0x20, 0x18, 0x0 });
+            long statsStructAddressPrevious = _ram.ResolvePointerPath64(_ram.BaseAddress + 0x84B9A0, new int[] { 0x28, 0x30, 0x88, 0x20, 0x90, 0x10, 0x20, 0x18, 0x0 });
+
+            if (statsStructAddressPrevious > 0)
+            {
+                try
+                {
+                    // tilesValuePrevious = _ram.ReadUint32(statsStructAddressPrevious + 0x2C);
+                    scoreValuePrevious = _ram.ReadUint32(statsStructAddressPrevious + 0x14);
+                    questValuePrevious = _ram.ReadUint32(statsStructAddressPrevious + 0x24);
+                    perfectValuePrevious = _ram.ReadUint32(statsStructAddressPrevious + 0x20);
+                }
+                catch
+                { }
+            }
+
+            // Backup pointer
+            // _ram.ResolvePointerPath64(_ram.BaseAddress + 0x98B9B8, new int[] { 0x28, 0x30, 0x88, 0x20, 0x90, 0x10, 0x28, 0x18, 0x0 });
+            long statsStructAddress = _ram.ResolvePointerPath64(_ram.BaseAddress + 0x84B9A0, new int[] { 0x28, 0x30, 0x88, 0x20, 0x90, 0x10, 0x28, 0x18, 0x0 });
+
+            if (statsStructAddress > 0)
+            {
+                try
+                {
+                    // tilesValue = _ram.ReadUint32(statsStructAddress + 0x2C);
+                    scoreValue = _ram.ReadUint32(statsStructAddress + 0x14);
+                    questValue = _ram.ReadUint32(statsStructAddress + 0x24);
+                    perfectValue = _ram.ReadUint32(statsStructAddress + 0x20);
+
+                    _scoreQuest.UpdateValue((long)scoreValue);
+                    _questQuest.UpdateValue((long)questValue);
+                    _perfectQuest.UpdateValue((long)perfectValue);
+                }
+                catch
+                {}
+            }
+            else
+            {
+                if (scoreValuePrevious != null)
+                {
+                    _scoreQuest.UpdateValue((long)scoreValuePrevious);
+                }
+
+                if (questValuePrevious != null)
+                {
+                    _questQuest.UpdateValue((long)questValuePrevious);
+                }
+
+                if (perfectValuePrevious != null)
+                {
+                    _perfectQuest.UpdateValue((long)perfectValuePrevious);
+                }
+            }
 
             return true;
         }

--- a/HintMachine/Games/DorfromantikConnector.cs
+++ b/HintMachine/Games/DorfromantikConnector.cs
@@ -55,6 +55,8 @@ namespace HintMachine.Games
 
         public override bool Poll()
         {
+            if (_ram.TestProcess() == false) { return false; }
+
             // long? tilesValuePrevious = null;
             long? scoreValuePrevious = null;
             long? questValuePrevious = null;

--- a/HintMachine/Games/IslandersConnector.cs
+++ b/HintMachine/Games/IslandersConnector.cs
@@ -14,7 +14,7 @@
             Name = "Booster Packs Earned",
             GoalValue = 5,
             MaxIncrease = 2,
-            TimeoutBetweenIncrements = 15,
+            CooldownBetweenIncrements = 15,
         };
 
         private readonly HintQuestCumulative _islandQuest = new HintQuestCumulative
@@ -22,7 +22,7 @@
             Name = "Islands Visited",
             GoalValue = 3,
             MaxIncrease = 1,
-            TimeoutBetweenIncrements = 60,
+            CooldownBetweenIncrements = 60,
         };
 
         private ProcessRamWatcher _ram = null;
@@ -58,7 +58,7 @@
 
             long localGameManagerStructAddress = _ram.ResolvePointerPath64(_ram.BaseAddress + 0x7521F0, new int[] { 0x210, 0x700, 0x20, 0x5A0 });
 
-            if (localGameManagerStructAddress > 0)
+            if (localGameManagerStructAddress != 0)
             {
                 try
                 {

--- a/HintMachine/Games/LuckBeALandlordConnector.cs
+++ b/HintMachine/Games/LuckBeALandlordConnector.cs
@@ -43,7 +43,7 @@ namespace HintMachine.Games
             long coinStructAddress = _ram.ResolvePointerPath64(_ram.BaseAddress + 0x21EFC90, new int[] { 0x218, 0x108, 0x10, 0x58, 0x20, 0x660 });
             long spinStructAddress = _ram.ResolvePointerPath64(_ram.BaseAddress + 0x21EFC90, new int[] { 0x218, 0x108, 0x38, 0x108, 0x0, 0x58, 0x20, 0x2D0 });
 
-            if (coinStructAddress > 0 && spinStructAddress > 0)
+            if (coinStructAddress != 0 && spinStructAddress != 0)
             {
                 try
                 {

--- a/HintMachine/Games/PacManChampionshipEditionDXConnector.cs
+++ b/HintMachine/Games/PacManChampionshipEditionDXConnector.cs
@@ -4,7 +4,7 @@ namespace HintMachine.Games
     {
         private readonly HintQuestCumulative _scoreQuest = new HintQuestCumulative
         {
-            Name = "Cumulative Score",
+            Name = "Score",
             GoalValue = 400000,
         };
 


### PR DESCRIPTION
**In this PR**

**Dorfromantik**
* Now looking at different structs (RewardSystemData) that have the state of the last 2 moves instead
* Found solid pointers to those new structs (extensively tested). Documented some backups just in case
* Added new quests for Quests Fulfilled + Perfect Tile Placements
* Now handling process being killed correctly
![image](https://github.com/CalDrac/hintMachine/assets/35039/a01f2373-5601-4a38-8644-ec38e480d5cb)

**ISLANDERS**
* Now looking at LocalGameManager struct instead
* Found solid pointer to that new struct (extensively tested)
* Added new quests for Booster Packs Earned + Islands Visited
* Now handling process being killed correctly
![image](https://github.com/CalDrac/hintMachine/assets/35039/be17457e-1154-45ac-91a9-302f8b458160)

**PAC-MAN Championship Edition DX+**
* Minor: Rename Cumulative Score to Score for consistency across implementations
![image](https://github.com/CalDrac/hintMachine/assets/35039/432a900a-df45-4770-a7a4-d554f033a7a8)