### PR TITLE
Serpent Games: Switch to Binary Targets

### DIFF
--- a/HintMachine/Games/DorfromantikConnector.cs
+++ b/HintMachine/Games/DorfromantikConnector.cs
@@ -2,6 +2,14 @@ namespace HintMachine.Games
 {
     public class DorfromantikConnector : IGameConnector
     {
+        private readonly BinaryTarget GAME_VERSION_STEAM = new BinaryTarget
+        {
+            DisplayName = "Steam",
+            ProcessName = "Dorfromantik",
+            ModuleName = "mono-2.0-bdwgc.dll",
+            Hash = "4C7312A39FA8401AF0D51D210931DAE8C8D85BBFE8E1C7F22E8A553E6D00B0EE"
+        };
+
         private readonly HintQuestCumulative _scoreQuest = new HintQuestCumulative
         {
             Name = "Score",
@@ -45,7 +53,9 @@ namespace HintMachine.Games
 
         public override bool Connect()
         {
-            _ram = new ProcessRamWatcher("Dorfromantik", "mono-2.0-bdwgc.dll");
+            _ram = new ProcessRamWatcher();
+            _ram.SupportedTargets.Add(GAME_VERSION_STEAM);
+
             return _ram.TryConnect();
         }
 

--- a/HintMachine/Games/DorfromantikConnector.cs
+++ b/HintMachine/Games/DorfromantikConnector.cs
@@ -53,9 +53,7 @@ namespace HintMachine.Games
 
         public override bool Connect()
         {
-            _ram = new ProcessRamWatcher();
-            _ram.SupportedTargets.Add(GAME_VERSION_STEAM);
-
+            _ram = new ProcessRamWatcher(GAME_VERSION_STEAM);
             return _ram.TryConnect();
         }
 

--- a/HintMachine/Games/IslandersConnector.cs
+++ b/HintMachine/Games/IslandersConnector.cs
@@ -2,6 +2,14 @@
 {
     public class IslandersConnector : IGameConnector
     {
+        private readonly BinaryTarget GAME_VERSION_STEAM = new BinaryTarget
+        {
+            DisplayName = "Steam",
+            ProcessName = "ISLANDERS",
+            ModuleName = "mono-2.0-bdwgc.dll",
+            Hash = "1D29EAED8E610CE4370DB1B396D4DD7C5FED0DB267D18BF97CA91E865100B71E"
+        };
+
         private readonly HintQuestCumulative _scoreQuest = new HintQuestCumulative
         {
             Name = "Score",
@@ -43,7 +51,9 @@
 
         public override bool Connect()
         {
-            _ram = new ProcessRamWatcher("ISLANDERS", "mono-2.0-bdwgc.dll");
+            _ram = new ProcessRamWatcher();
+            _ram.SupportedTargets.Add(GAME_VERSION_STEAM);
+
             return _ram.TryConnect();
         }
 

--- a/HintMachine/Games/IslandersConnector.cs
+++ b/HintMachine/Games/IslandersConnector.cs
@@ -51,9 +51,7 @@
 
         public override bool Connect()
         {
-            _ram = new ProcessRamWatcher();
-            _ram.SupportedTargets.Add(GAME_VERSION_STEAM);
-
+            _ram = new ProcessRamWatcher(GAME_VERSION_STEAM);
             return _ram.TryConnect();
         }
 

--- a/HintMachine/Games/LuckBeALandlordConnector.cs
+++ b/HintMachine/Games/LuckBeALandlordConnector.cs
@@ -2,6 +2,13 @@ namespace HintMachine.Games
 {
     public class LuckBeALandlordConnector : IGameConnector
     {
+        private readonly BinaryTarget GAME_VERSION_STEAM = new BinaryTarget
+        {
+            DisplayName = "Steam",
+            ProcessName = "Luck be a Landlord",
+            Hash = "8A6EB15E774ED5F85B2CC8F70CCA4FC3EEFE69898A6AE418982065CAB5665740"
+        };
+
         private readonly HintQuestCumulative _coinQuest = new HintQuestCumulative
         {
             Name = "Coins Spent",
@@ -27,7 +34,9 @@ namespace HintMachine.Games
 
         public override bool Connect()
         {
-            _ram = new ProcessRamWatcher("Luck be a Landlord");
+            _ram = new ProcessRamWatcher();
+            _ram.SupportedTargets.Add(GAME_VERSION_STEAM);
+
             return _ram.TryConnect();
         }
 

--- a/HintMachine/Games/LuckBeALandlordConnector.cs
+++ b/HintMachine/Games/LuckBeALandlordConnector.cs
@@ -34,9 +34,7 @@ namespace HintMachine.Games
 
         public override bool Connect()
         {
-            _ram = new ProcessRamWatcher();
-            _ram.SupportedTargets.Add(GAME_VERSION_STEAM);
-
+            _ram = new ProcessRamWatcher(GAME_VERSION_STEAM);
             return _ram.TryConnect();
         }
 

--- a/HintMachine/Games/PacManChampionshipEditionDXConnector.cs
+++ b/HintMachine/Games/PacManChampionshipEditionDXConnector.cs
@@ -31,9 +31,7 @@ namespace HintMachine.Games
 
         public override bool Connect()
         {
-            _ram = new ProcessRamWatcher();
-            _ram.SupportedTargets.Add(GAME_VERSION_STEAM);
-
+            _ram = new ProcessRamWatcher(GAME_VERSION_STEAM);
             return _ram.TryConnect();
         }
 

--- a/HintMachine/Games/PacManChampionshipEditionDXConnector.cs
+++ b/HintMachine/Games/PacManChampionshipEditionDXConnector.cs
@@ -2,6 +2,13 @@ namespace HintMachine.Games
 {
     public class PacManChampionshipEditionDXConnector : IGameConnector
     {
+        private readonly BinaryTarget GAME_VERSION_STEAM = new BinaryTarget
+        {
+            DisplayName = "Steam",
+            ProcessName = "PAC-MAN",
+            Hash = "B96AAB05C2A3E767FDE271A14A0052915D89418F000F5BDE75B74777608721F1"
+        };
+
         private readonly HintQuestCumulative _scoreQuest = new HintQuestCumulative
         {
             Name = "Score",
@@ -24,7 +31,9 @@ namespace HintMachine.Games
 
         public override bool Connect()
         {
-            _ram = new ProcessRamWatcher("PAC-MAN");
+            _ram = new ProcessRamWatcher();
+            _ram.SupportedTargets.Add(GAME_VERSION_STEAM);
+
             return _ram.TryConnect();
         }
 


### PR DESCRIPTION
Switched my 4 merged games to use `BinaryTarget`. All tested to work fine post-change.