### PR TITLE
Post Game Update Fix: TMNT Shredder's Revenge

### DIFF
--- a/HintMachine/Models/Games/TMNTShreddersRevengeConnector.cs
+++ b/HintMachine/Models/Games/TMNTShreddersRevengeConnector.cs
@@ -8,7 +8,7 @@ namespace HintMachine.Models.Games
         {
             DisplayName = "Steam",
             ProcessName = "TMNT",
-            Hash = "84DF2BBE0C0E45A83A1991C46635E11F32E7AADD4086E1F810EC1B61CB7B4952"
+            Hash = "8AAA6D910754E1B84D62702BF66BE4C22D46EA23D6DC0B80AD9761909EE22389"
         };
 
         private readonly HintQuestCumulative _enemyQuest = new HintQuestCumulative


### PR DESCRIPTION
Only needed an executable hash update. Pointer is still good.