### PR TITLE
Post Game Update Fixes: ISLANDERS, Skyrim Special Edition, TMNT Shredder's Revenge

### DIFF
--- a/HintMachine/Models/Games/IslandersConnector.cs
+++ b/HintMachine/Models/Games/IslandersConnector.cs
@@ -11,7 +11,7 @@ namespace HintMachine.Models.Games
             DisplayName = "Steam",
             ProcessName = "ISLANDERS",
             ModuleName = "mono-2.0-bdwgc.dll",
-            Hash = "1D29EAED8E610CE4370DB1B396D4DD7C5FED0DB267D18BF97CA91E865100B71E"
+            Hash = "9631CBCFC993231121691740FF8D1B80EA671E548A3D74274E625BD51676997D"
         };
 
         private readonly HintQuestCumulative _scoreQuest = new HintQuestCumulative

--- a/HintMachine/Models/Games/SkyrimSpecialEditionConnector.cs
+++ b/HintMachine/Models/Games/SkyrimSpecialEditionConnector.cs
@@ -11,7 +11,7 @@ namespace HintMachine.Models.Games
         {
             DisplayName = "Steam",
             ProcessName = "SkyrimSE",
-            Hash = "EB77D225CDD1832076001281C3C570DD0C95864AC5748701E0CF5652B2A24517"
+            Hash = "537527CEC58E458425255B320844F0F1DAC1A902A93D21891A50DF7C1F238B8D"
         };
 
         private readonly HintQuestCumulative _dungeonsClearedQuest = new HintQuestCumulative
@@ -213,7 +213,7 @@ namespace HintMachine.Models.Games
 
         protected override bool Poll()
         {
-            long generalStatsStructAddress = _ram.ResolvePointerPath64(_ram.BaseAddress + 0x2F5F128, new int[] { 0x240 });
+            long generalStatsStructAddress = _ram.ResolvePointerPath64(_ram.BaseAddress + 0x30F0018, new int[] { 0x240 });
 
             if (generalStatsStructAddress != 0)
             {

--- a/HintMachine/Models/Games/TMNTShreddersRevengeConnector.cs
+++ b/HintMachine/Models/Games/TMNTShreddersRevengeConnector.cs
@@ -10,7 +10,7 @@ namespace HintMachine.Models.Games
         {
             DisplayName = "Steam",
             ProcessName = "TMNT",
-            Hash = "8AAA6D910754E1B84D62702BF66BE4C22D46EA23D6DC0B80AD9761909EE22389"
+            Hash = "3D812412D2E41FF3452CA6D6077CC9276970BE15D796B88F06C70D573A4051A6"
         };
 
         private readonly HintQuestCumulative _enemyQuest = new HintQuestCumulative


### PR DESCRIPTION
Only Skyrim needed a new pointer, other games were fine with just an executable hash update